### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,21 +1,27 @@
 backend:
-  - backend/**
+  - changed-files:
+      - any-glob-to-any-file: ['backend/**']
 
 frontend:
-  - frontend/**
+  - changed-files:
+      - any-glob-to-any-file: ['frontend/**']
 
 ci:
-  - .github/**
-  - pyproject.toml
-  - .pre-commit-config.yaml
-  - .editorconfig
-  - .flake8
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'pyproject.toml'
+          - '.pre-commit-config.yaml'
+          - '.editorconfig'
+          - '.flake8'
 
 docs:
-  - '**/*.md'
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.md']
 
 dependencies:
-  - '**/requirements.txt'
-  - '**/environment.yml'
-  - .github/dependabot.yml
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/requirements.txt'
+          - '**/environment.yml'
+          - '.github/dependabot.yml'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,30 @@
 backend:
   - changed-files:
-      - any-glob-to-any-file: ['backend/**']
+      any-glob-to-any-file:
+        - 'backend/**'
 
 frontend:
   - changed-files:
-      - any-glob-to-any-file: ['frontend/**']
+      any-glob-to-any-file:
+        - 'frontend/**'
 
 ci:
   - changed-files:
-      - any-glob-to-any-file:
-          - '.github/**'
-          - 'pyproject.toml'
-          - '.pre-commit-config.yaml'
-          - '.editorconfig'
-          - '.flake8'
+      any-glob-to-any-file:
+        - '.github/**'
+        - 'pyproject.toml'
+        - '.pre-commit-config.yaml'
+        - '.editorconfig'
+        - '.flake8'
 
 docs:
   - changed-files:
-      - any-glob-to-any-file: ['**/*.md']
+      any-glob-to-any-file:
+        - '**/*.md'
 
 dependencies:
   - changed-files:
-      - any-glob-to-any-file:
-          - '**/requirements.txt'
-          - '**/environment.yml'
-          - '.github/dependabot.yml'
+      any-glob-to-any-file:
+        - '**/requirements.txt'
+        - '**/environment.yml'
+        - '.github/dependabot.yml'

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -52,6 +52,6 @@ def ask_about_listings(
     try:
         resp = client.chat(model=chosen_model, messages=messages, temperature=0.2, max_tokens=300)
         return resp
-    except Exception as e:
+    except Exception:
         logging.exception("LLM request failed")
         return "LLM request failed due to an internal error."

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,5 +1,6 @@
 import os
 from typing import List, Optional
+import logging
 
 from ..models.models import ItemDTO
 from .openai_client import OpenAIClient
@@ -52,4 +53,5 @@ def ask_about_listings(
         resp = client.chat(model=chosen_model, messages=messages, temperature=0.2, max_tokens=300)
         return resp
     except Exception as e:
-        return f"LLM request failed: {str(e)}"
+        logging.exception("LLM request failed")
+        return "LLM request failed due to an internal error."


### PR DESCRIPTION
Potential fix for [https://github.com/daniel-volpin/CSFloat/security/code-scanning/1](https://github.com/daniel-volpin/CSFloat/security/code-scanning/1)

The best fix is to prevent exception messages or stack traces from being sent to the user. Instead, log the detailed error internally (e.g., using Python's `logging` module), and only return a generic error message to the frontend/user. Specifically, in `ask_about_listings` in `backend/services/llm_client.py`, the exception handler at line 54 should log the real error and return a generic constant string to the caller. This ensures that clients of the API only ever see a non-descriptive message like "LLM request failed due to an internal error." No changes are needed on the FastAPI endpoint unless you want to harmonize error messages, but the core of the fix must be in `ask_about_listings`.

To implement this:
- Add an import for the `logging` module if not present.
- In the except block of `ask_about_listings`, log the exception using `logging.exception("LLM request failed")`.
- Return a fixed string, e.g., "LLM request failed due to an internal error." rather than including exception contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
